### PR TITLE
Auto upgrade aptos cli to latest

### DIFF
--- a/bin/aptos
+++ b/bin/aptos
@@ -157,7 +157,7 @@ const main = async () => {
       console.log(`A newer version of the CLI is available: ${latestVersion}`);
       installCli(os, path, latestVersion);
     } else {
-      console.log(`CLI is already up to date`);
+      console.log(`CLI is up to date`);
     }
   }
 

--- a/bin/aptos
+++ b/bin/aptos
@@ -98,7 +98,7 @@ const installCli = (os, path, latestVersion) => {
   if (os === "Windows") {
     // Download the zip file, extract it, and move the binary to the correct location.
     execSync(
-      `powershell -Command "Invoke-RestMethod -Uri ${url} -OutFile .\\aptos.zip; Expand-Archive -Path .\\aptos.zip -DestinationPath . -Force; Move-Item -Path .\\aptos\\aptos.exe -Destination ${path}"`
+      `powershell -Command "if (!(Test-Path -Path 'C:\\tmp')) { New-Item -ItemType Directory -Path 'C:\\tmp' } ; Invoke-RestMethod -Uri ${url} -OutFile C:\\tmp\\aptos.zip; Expand-Archive -Path C:\\tmp\\aptos.zip -DestinationPath C:\\tmp -Force; Move-Item -Path C:\\tmp\\aptos\\aptos.exe -Destination ${path}"`
     );
   } else if (os === "MacOS") {
     // Install the CLI with brew.

--- a/bin/aptos
+++ b/bin/aptos
@@ -98,7 +98,7 @@ const installCli = (os, path, latestVersion) => {
   if (os === "Windows") {
     // Download the zip file, extract it, and move the binary to the correct location.
     execSync(
-      `powershell -Command "if (!(Test-Path -Path 'C:\\tmp')) { New-Item -ItemType Directory -Path 'C:\\tmp' } ; Invoke-RestMethod -Uri ${url} -OutFile C:\\tmp\\aptos.zip; Expand-Archive -Path C:\\tmp\\aptos.zip -DestinationPath C:\\tmp -Force; Move-Item -Path C:\\tmp\\aptos\\aptos.exe -Destination ${path}"`
+      `powershell -Command "if (!(Test-Path -Path 'C:\\tmp')) { New-Item -ItemType Directory -Path 'C:\\tmp' } ; Invoke-RestMethod -Uri ${url} -OutFile C:\\tmp\\aptos.zip; Expand-Archive -Path C:\\tmp\\aptos.zip -DestinationPath C:\\tmp -Force; Move-Item -Path C:\\tmp\\aptos.exe -Destination ${path}"`
     );
   } else if (os === "MacOS") {
     // Install the CLI with brew.

--- a/bin/aptos
+++ b/bin/aptos
@@ -72,6 +72,15 @@ const getLatestVersionBrew = () => {
   return out[0].versions.stable;
 };
 
+// Determine the latest version of the CLI.
+const getLatestVersion = async () => {
+  if (os === "MacOS") {
+    return getLatestVersionBrew();
+  } else {
+    return getLatestVersionGh();
+  }
+};
+
 // Based on the installation path of the aptos formula, determine the path where the
 // CLI should be installed.
 const getCliPathBrew = () => {
@@ -79,6 +88,29 @@ const getCliPathBrew = () => {
     .toString()
     .trim();
   return `${directory}/bin/aptos`;
+};
+
+// Install or update the CLI.
+const installCli = (os, path, latestVersion) => {
+  const url = `https://github.com/aptos-labs/aptos-core/releases/download/${PNAME}-v${latestVersion}/${PNAME}-${latestVersion}-${os}-x86_64.zip`;
+
+  console.log(`Downloading aptos CLI version ${latestVersion}`);
+  if (os === "Windows") {
+    // Download the zip file, extract it, and move the binary to the correct location.
+    execSync(
+      `curl -L -o C:/tmp/aptos.zip ${url} & powershell Expand-Archive -Path C:/tmp/aptos.zip -DestinationPath C:/tmp -Force & move C:\\tmp\\aptos.exe ${path}`
+    );
+  } else if (os === "MacOS") {
+    // Install the CLI with brew.
+    execSyncShell("brew install aptos");
+    // Get the path of the CLI.
+    path = getCliPathBrew();
+  } else {
+    // Download the zip file, extract it, and move the binary to the correct location.
+    execSync(
+      `curl -L -o /tmp/aptos.zip ${url}; unzip -o -q /tmp/aptos.zip -d /tmp; mv /tmp/aptos ${path};`
+    );
+  }
 };
 
 const main = async () => {
@@ -102,34 +134,30 @@ const main = async () => {
     path = `${__dirname}/${PNAME}`;
   }
 
+  // Look up the latest version.
+  const latestVersion = await getLatestVersion();
+
   // If binary does not exist, download it.
   if (!fs.existsSync(path)) {
-    // Look up the latest version.
-    let latestVersion;
-    if (os === "MacOS") {
-      latestVersion = getLatestVersionBrew();
+    console.log("CLI not installed");
+    // Install the latest version.
+    installCli(os, path, latestVersion);
+  } else {
+    // Get the current version of the CLI.
+    const currentVersion = execSyncShell(`${path} --version`, {
+      encoding: "utf8",
+    })
+      .trim()
+      .split(" ")[1];
+    console.log(
+      `Previously installed CLI version ${currentVersion}, checking for updates`
+    );
+    // Check if the installed version is the latest version.
+    if (currentVersion !== latestVersion) {
+      console.log(`A newer version of the CLI is available: ${latestVersion}`);
+      installCli(os, path, latestVersion);
     } else {
-      latestVersion = await getLatestVersionGh();
-    }
-
-    const url = `https://github.com/aptos-labs/aptos-core/releases/download/${PNAME}-v${latestVersion}/${PNAME}-${latestVersion}-${os}-x86_64.zip`;
-
-    console.log(`Downloading aptos CLI version ${latestVersion}`);
-    if (os === "Windows") {
-      // Download the zip file, extract it, and move the binary to the correct location.
-      execSync(
-        `curl -L -o C:/tmp/aptos.zip ${url} & powershell Expand-Archive -Path C:/tmp/aptos.zip -DestinationPath C:/tmp -Force & move C:\\tmp\\aptos.exe ${path}`
-      );
-    } else if (os === "MacOS") {
-      // Install the CLI with brew.
-      execSyncShell("brew install aptos");
-      // Get the path of the CLI.
-      path = getCliPathBrew();
-    } else {
-      // Download the zip file, extract it, and move the binary to the correct location.
-      execSync(
-        `curl -L -o /tmp/aptos.zip ${url}; unzip -o -q /tmp/aptos.zip -d /tmp; mv /tmp/aptos ${path};`
-      );
+      console.log(`CLI is already up to date`);
     }
   }
 

--- a/bin/aptos
+++ b/bin/aptos
@@ -98,7 +98,7 @@ const installCli = (os, path, latestVersion) => {
   if (os === "Windows") {
     // Download the zip file, extract it, and move the binary to the correct location.
     execSync(
-      `Invoke-RestMethod -Uri ${url} -OutFile .\\aptos.zip; Expand-Archive -Path .\\aptos.zip -DestinationPath . -Force; Move-Item -Path .\\aptos\\aptos.exe -Destination ${path}`
+      `powershell -Command "Invoke-RestMethod -Uri ${url} -OutFile .\\aptos.zip; Expand-Archive -Path .\\aptos.zip -DestinationPath . -Force; Move-Item -Path .\\aptos\\aptos.exe -Destination ${path}"`
     );
   } else if (os === "MacOS") {
     // Install the CLI with brew.

--- a/bin/aptos
+++ b/bin/aptos
@@ -98,7 +98,7 @@ const installCli = (os, path, latestVersion) => {
   if (os === "Windows") {
     // Download the zip file, extract it, and move the binary to the correct location.
     execSync(
-      `curl -L -o C:/tmp/aptos.zip ${url} & powershell Expand-Archive -Path C:/tmp/aptos.zip -DestinationPath C:/tmp -Force & move C:\\tmp\\aptos.exe ${path}`
+      `Invoke-RestMethod -Uri ${url} -OutFile .\\aptos.zip; Expand-Archive -Path .\\aptos.zip -DestinationPath . -Force; Move-Item -Path .\\aptos\\aptos.exe -Destination ${path}`
     );
   } else if (os === "MacOS") {
     // Install the CLI with brew.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptos-labs/aptos-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Aptos CLI available from npmjs",
   "bin": {
     "aptos": "bin/aptos"


### PR DESCRIPTION
#13 

Previously if user already has aptos cli installed, we won't do anything, now change it to upgrade to latest if already installed.

Tested on windows.

```sh
aptos-cli git:(j/auto-upgrade-aptos) ✗ node bin/aptos
Already installed CLI version 3.4.1, checking for updates
CLI is already up to date
Command Line Interface (CLI) for developing and interacting with the Aptos blockchain

Usage: aptos <COMMAND>
```