### PR TITLE
fix linux version to download, add github workflows

### DIFF
--- a/.github/workflows/run-bin-script-on-mac.yaml
+++ b/.github/workflows/run-bin-script-on-mac.yaml
@@ -1,0 +1,18 @@
+name: Run bin script on Mac
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: macos-latest
+    concurrency: ci-${{ github.ref }}-${{ github.workflow }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run the bin script on Mac
+        run: node bin/aptos

--- a/.github/workflows/run-bin-script-on-ubuntu.yaml
+++ b/.github/workflows/run-bin-script-on-ubuntu.yaml
@@ -1,0 +1,18 @@
+name: Run bin script on Ubuntu
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency: ci-${{ github.ref }}-${{ github.workflow }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run the bin script on Ubuntu
+        run: node bin/aptos

--- a/.github/workflows/run-bin-script-on-windows.yaml
+++ b/.github/workflows/run-bin-script-on-windows.yaml
@@ -1,0 +1,19 @@
+name: Run bin script on Windows
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+    concurrency: ci-${{ github.ref }}-${{ github.workflow }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run the bin script on Windows
+        run: node bin/aptos
+        shell: cmd

--- a/bin/aptos
+++ b/bin/aptos
@@ -14,6 +14,8 @@ const fs = require("fs");
 const os = require("os");
 
 const PNAME = "aptos-cli";
+const GH_CLI_DOWNLOAD_URL =
+  "https://github.com/aptos-labs/aptos-core/releases/download";
 
 // Wrapper around execSync that uses the shell.
 const execSyncShell = (command, options) => {
@@ -74,11 +76,17 @@ const getLatestVersionBrew = () => {
 
 // Determine the latest version of the CLI.
 const getLatestVersion = async () => {
-  if (os === "MacOS") {
+  if (getOS() === "MacOS") {
     return getLatestVersionBrew();
   } else {
     return getLatestVersionGh();
   }
+};
+
+// Determine the current SSL version
+const getCurrentOpenSSLVersion = () => {
+  const out = execSyncShell("openssl version", { encoding: "utf8" });
+  return out.split(" ")[1].trim();
 };
 
 // Based on the installation path of the aptos formula, determine the path where the
@@ -91,11 +99,10 @@ const getCliPathBrew = () => {
 };
 
 // Install or update the CLI.
-const installCli = (os, path, latestVersion) => {
-  const url = `https://github.com/aptos-labs/aptos-core/releases/download/${PNAME}-v${latestVersion}/${PNAME}-${latestVersion}-${os}-x86_64.zip`;
-
-  console.log(`Downloading aptos CLI version ${latestVersion}`);
+const installCli = (os, path, latestCLIVersion) => {
+  console.log(`Downloading aptos CLI version ${latestCLIVersion}`);
   if (os === "Windows") {
+    const url = `${GH_CLI_DOWNLOAD_URL}/${PNAME}-v${latestCLIVersion}/${PNAME}-${latestCLIVersion}-${os}-x86_64.zip`;
     // Download the zip file, extract it, and move the binary to the correct location.
     execSync(
       `powershell -Command "if (!(Test-Path -Path 'C:\\tmp')) { New-Item -ItemType Directory -Path 'C:\\tmp' } ; Invoke-RestMethod -Uri ${url} -OutFile C:\\tmp\\aptos.zip; Expand-Archive -Path C:\\tmp\\aptos.zip -DestinationPath C:\\tmp -Force; Move-Item -Path C:\\tmp\\aptos.exe -Destination ${path}"`
@@ -106,6 +113,23 @@ const installCli = (os, path, latestVersion) => {
     // Get the path of the CLI.
     path = getCliPathBrew();
   } else {
+    // On Linux, we check what version of OpenSSL we're working with to figure out
+    // which binary to download.
+    let osVersion = "x86_64";
+    let opensSslVersion = "1.0.0";
+    try {
+      opensSslVersion = getCurrentOpenSSLVersion();
+    } catch (error) {
+      console.log(
+        "Could not determine OpenSSL version, assuming older version (1.x.x)"
+      );
+    }
+
+    if (opensSslVersion.startsWith("3.")) {
+      osVersion = "22.04-x86_64";
+    }
+    console.log(`Downloading CLI binary ${os}-${osVersion}`);
+    const url = `${GH_CLI_DOWNLOAD_URL}/${PNAME}-v${latestCLIVersion}/${PNAME}-${latestCLIVersion}-${os}-${osVersion}.zip`;
     // Download the zip file, extract it, and move the binary to the correct location.
     execSync(
       `curl -L -o /tmp/aptos.zip ${url}; unzip -o -q /tmp/aptos.zip -d /tmp; mv /tmp/aptos ${path};`


### PR DESCRIPTION
Fix for linux downloads by first checking the user installed SSL version and download the Linux version based on that

This follows the logic is the main CLI script download https://aptos-org.slack.com/archives/C03N83P7QUC/p1720706183093929